### PR TITLE
Remove unused e flag from preg_replace

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -108,7 +108,7 @@ class syntax_plugin_alphaindex extends DokuWiki_Syntax_Plugin {
 
             // remove toc, section edit buttons and category tags
             $patterns = array('!<div class="toc">.*?(</div>\n</div>)!s',
-                            '#<!-- SECTION \[(\d*-\d*)\] -->#e',
+                            '#<!-- SECTION \[(\d*-\d*)\] -->#',
                             '!<div class="category">.*?</div>!s');
             $replace  = array('','','');
             $alpha_data = preg_replace($patterns, $replace, $alpha_data);


### PR DESCRIPTION
Since it causes problems with newer php version, is not used anyway and the regular expression does not execute, the e flag has been removed. 